### PR TITLE
Too many request fix

### DIFF
--- a/fyndiqmerchant/backoffice/controllers.php
+++ b/fyndiqmerchant/backoffice/controllers.php
@@ -170,8 +170,6 @@ class FmBackofficeControllers
 
             # authenticate with Fyndiq API
             try {
-                FmHelpers::call_api_raw($username, $api_token, 'GET', 'settings/', array());
-                sleep(1);
                 # if no exceptions, authentication is successful
                 FmConfig::set('username', $username);
                 FmConfig::set('api_token', $api_token);


### PR DESCRIPTION
It was called the api too fast, creating the too many request error to appear.
I tested with using sleep and it works. I wonder if you, @aquilax have a better idea of fixing this? I have here my way on fixing the issue. Not so beautiful IMO.

closes #104 
