### PR TITLE
Get correct shop id

### DIFF
--- a/fyndiqmerchant/backoffice/helpers.php
+++ b/fyndiqmerchant/backoffice/helpers.php
@@ -205,9 +205,12 @@ class FmHelpers
      */
     public static function getCurrentShopId()
     {
-        $context = Shop::getContext();
-        if (Shop::isFeatureActive() && !is_numeric($context->cookie->shopContext)) {
-            return intval($context->cookie->shopContext);
+        $context = Context::getContext();
+        if (Shop::isFeatureActive() && $context->cookie->shopContext) {
+            $split = explode('-', $context->cookie->shopContext);
+            if (count($split) === 2) {
+                return intval($split[1]);
+            }
         }
         return intval(Shop::getCurrentShop());
     }

--- a/fyndiqmerchant/backoffice/service.php
+++ b/fyndiqmerchant/backoffice/service.php
@@ -1,7 +1,20 @@
 <?php
 
+$storeRoot = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME']))));
+
+$timer_start = microtime(true);
+
+// NOTE: This root is wrong but config relies on these constants to be set to populate the proper context
+if (!defined('_PS_ADMIN_DIR_')){
+    define('_PS_ADMIN_DIR_', $storeRoot);
+}
+if (!defined('PS_ADMIN_DIR')) {
+    define('PS_ADMIN_DIR', _PS_ADMIN_DIR_);
+}
+
 # import PrestaShop config, to enable use of PrestaShop classes, like Configuration
-$configPath = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])))) . '/config/config.inc.php';
+$configPath = $storeRoot . '/config/config.inc.php';
+
 if (file_exists($configPath)) {
     require_once($configPath);
 } else {


### PR DESCRIPTION
Getting the correct shop id in PrestaShop proves to be tricky business. It's stored in a cookie in `c-id` format where `c` is the current context. And to get the proper context `_PS_ADMIN_DIR_` has to be set.

/cc @confact 
