### PR TITLE
Don't link gategories for all products

### DIFF
--- a/src/backoffice/models/FmProduct.php
+++ b/src/backoffice/models/FmProduct.php
@@ -33,8 +33,6 @@ class FmProduct extends FmModel
             $sqlQuery = '
                 SELECT p.id_product
                 FROM ' . $this->fmPrestashop->globDbPrefix() . 'product p
-                JOIN ' . $this->fmPrestashop->globDbPrefix() . 'category_product as cp
-                WHERE p.id_product = cp.id_product
                 LIMIT ' . $offset . ', ' . $perPage;
         }
         $rows = $this->fmPrestashop->dbGetInstance()->ExecuteS($sqlQuery);


### PR DESCRIPTION
All products link must not join categories as one product can be in multiple categories, thus leading to duplication :key: 

/cc @confact 
