### PR TITLE
Don't skip epty SKU-s for combinations

### DIFF
--- a/src/backoffice/models/FmProductExport.php
+++ b/src/backoffice/models/FmProductExport.php
@@ -212,9 +212,6 @@ class FmProductExport extends FmModel
             $combinationImages = $product->getCombinationImages($languageId);
             foreach ($productAttributes as $fixingAttribute) {
                 $reference = $this->getProductSKU($skuTypeId, $product, $fixingAttribute);
-                if ($reference == '') {
-                    continue;
-                }
                 if (!isset($productAttributesFixed[$reference])) {
                     $productAttributesFixed[$reference] = array();
                 }


### PR DESCRIPTION
Don't skip epty SKU-s for combinations, because that leads to wrongly exported products.

@confact 
