### PR TITLE
Use default category if method available

### DIFF
--- a/src/backoffice/models/FmProductExport.php
+++ b/src/backoffice/models/FmProductExport.php
@@ -114,8 +114,12 @@ class FmProductExport extends FmModel
      * @param $categories
      * @return mixed
      */
-    private function getCategoryId($categories)
+    private function getCategoryId($product)
     {
+        if (method_exists($product, 'getDefaultCategory')) {
+            return $product->getDefaultCategory();
+        }
+        $categories = $product->getCategories();
         if (is_array($categories)) {
             return array_pop($categories);
         }
@@ -173,7 +177,7 @@ class FmProductExport extends FmModel
         $result = array(
             'id' => $product->id,
             'name' => $product->name,
-            'category_id' => $this->getCategoryId($product->getCategories()),
+            'category_id' => $this->getCategoryId($product),
             'reference' => $this->getProductSKU($skuTypeId, $product),
             'tax_rate' => $this->fmPrestashop->productGetTaxRate($product),
             'quantity' => $this->fmPrestashop->productGetQuantity($product->id),


### PR DESCRIPTION
Use default category if method available. Some older versions don't have it.

@confact 
