### PR TITLE
fixed manual import order duplication

### DIFF
--- a/src/backoffice/FmUtils.php
+++ b/src/backoffice/FmUtils.php
@@ -32,12 +32,4 @@ class FmUtils
     {
         return new FyndiqCSVFeedWriter($file);
     }
-
-    public static function jsonEncode($data)
-    {
-        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-            return json_encode($data, JSON_UNESCAPED_UNICODE);
-        }
-        return json_encode($data);
-    }
 }

--- a/src/backoffice/models/FmOrder.php
+++ b/src/backoffice/models/FmOrder.php
@@ -586,17 +586,6 @@ class FmOrder extends FmModel
     }
 
     /**
-     * remove table from database.
-     *
-     * @return bool
-     */
-    public function uninstall()
-    {
-        $tableName = $this->fmPrestashop->getTableName(FmUtils::MODULE_NAME, '_orders', true);
-        return $this->fmPrestashop->dbGetInstance()->Execute('DROP TABLE ' . $tableName);
-    }
-
-    /**
      * Try to match product by SKU
      *
      * @param string $productSKU

--- a/src/fyndiqmerchant.php
+++ b/src/fyndiqmerchant.php
@@ -96,9 +96,6 @@ class FyndiqMerchant extends Module
         // Remove the menu tab
         $ret &= $this->uninstallTab();
 
-        // drop order table
-        //$ret &= $fmOrder->uninstall();
-
         return (bool)$ret;
     }
 


### PR DESCRIPTION
We keep Fyndiq order table when uninstalling the module. therefore it doesn't create duplicate order when orders import manually.
