### PR TITLE
fixed prestashop price while importing an order

### DIFF
--- a/src/backoffice/models/FmOrder.php
+++ b/src/backoffice/models/FmOrder.php
@@ -289,11 +289,11 @@ class FmOrder extends FmModel
      */
     public function updateCustomProductPrice($context, $productId, $attributeId, $price)
     {
-        $calculateTax = 0;
+        $reduction = 0;
         if ($this->fmPrestashop->configurationGet('PS_TAX')) {
             $product = $this->fmPrestashop->productNew($productId, true, $context->language->id);
             $tax = (float)$product->tax_rate;
-            $calculateTax = (float)($tax * $price)/100;
+            $reduction = (float)($tax * $price)/100;
         }
         $specific_price = $this->fmPrestashop->newSpecificPrice($context->cart->id, $productId, $attributeId);
         $specific_price->id_cart = (int)$context->cart->id;
@@ -307,7 +307,7 @@ class FmOrder extends FmModel
         $specific_price->id_product_attribute = $attributeId;
         $specific_price->price = $price;
         $specific_price->from_quantity = 1;
-        $specific_price->reduction = $calculateTax;
+        $specific_price->reduction = $reduction;
         $specific_price->reduction_type = 'amount';
         $specific_price->from = '0000-00-00 00:00:00';
         $specific_price->to = '0000-00-00 00:00:00';


### PR DESCRIPTION
Fixed this issue which we have received from Tester.
1. Order price changes from Fyndiq on it’s way back to Prestashop. (same issue)
   This seems to be the case for Prestashop1614de. There might be some hidden percentage in the background that adds some form of value on top of the final price.
   Ex.
   Price from Fyndiq: 650.50
   Final price at Prestashop: 764.69
   It adds an extra tax on prestashop:
